### PR TITLE
Fix testing

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -25,13 +25,8 @@ jobs:
           echo "BODY=${BODY}"
           echo "PRERELEASE=${PRERELEASE}"
           echo "DRAFT=${DRAFT}"
-  yarn-install:
-    needs: test-changelog
-    runs-on: ubuntu-latest
-    steps:
-      - run: yarn install
   test:
-    needs: yarn-install
+    needs: test-changelog
     strategy:
       matrix:
         node-version: [12.x, 14.x, 16.x]
@@ -42,8 +37,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - run: yarn test
+      - run: yarn install
+      - run: yarn test --coverage
   publish-release:
     if: |
       github.event_name == 'push' &&

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -25,8 +25,13 @@ jobs:
           echo "BODY=${BODY}"
           echo "PRERELEASE=${PRERELEASE}"
           echo "DRAFT=${DRAFT}"
-  test:
+  yarn-install:
     needs: test-changelog
+    runs-on: ubuntu-latest
+    steps:
+      - run: yarn install
+  test:
+    needs: yarn-install
     strategy:
       matrix:
         node-version: [12.x, 14.x, 16.x]
@@ -38,7 +43,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn install
       - run: yarn test
   publish-release:
     if: |


### PR DESCRIPTION
This PR prevents the workflow from expecting the existence of a yarn.lock file, since that is getting removed from the repository.